### PR TITLE
Avoid code length overflow error in QRcode generation

### DIFF
--- a/src/app/features/invoke-wallet/components/qr-code/qr-code.component.ts
+++ b/src/app/features/invoke-wallet/components/qr-code/qr-code.component.ts
@@ -91,7 +91,7 @@ export class QrCodeComponent implements OnInit, OnDestroy {
 
   ngAfterViewInit() {
     if (this.isCrossDevice) {
-      new QRCode(this.qrCode.nativeElement, this.redirectUrl);
+      new QRCode(this.qrCode.nativeElement, this.redirectUrl.padEnd(300));
     }
   }
 


### PR DESCRIPTION
Hello team!

I bumped into the following small bug that I wanted to share with you.
Strings of length between ~192--225 characters cause a code length overflow error in the QR code generation step.

You can reproduce the bug with this string:
`"eudi-openid4vp://?client_id=Verifier&request_uri=https%3A%2F%2Fsnf-111111.vm.okeanos.grnet.gr%2Fwallet%2Frequest.jwt%2FPUIAKaaLa2JnERh8sKUT18AUHMCIeh_GRgTpdcZ936tCGCDwrYcjITGa8k97Vw6g7N5_Bs_rYL-xJVs1T7TiFA"`

This is a [reported bug of the underlying QRcode library](https://github.com/davidshimjs/qrcodejs/issues/78).

This PR proposes a workaround that pads the string used to generate a QRcode such that its length overcomes the range where the bug manifests.

A more appropriate solution could be to consider [a fork of the original library that fixes the bug](https://github.com/KeeeX/qrcodejs).

Kind regards,
Marios