### PR TITLE
Add support for SD-JWT VC 'dc+sd-jwt' media type

### DIFF
--- a/src/app/core/constants/attestations-per-format.ts
+++ b/src/app/core/constants/attestations-per-format.ts
@@ -132,7 +132,7 @@ export const PID_SD_JWT_VC_ATTRIBUTE_MAP: { [id: string]: string } = {
 
 export const ATTESTATIONS_BY_FORMAT: { [id: string]: Attestation[] } = {
   "mso_mdoc": [PID_MSO_MDOC, MDL_MSO_MDOC, PHOTO_ID_MSO_MDOC, AGE_OVER_18_MSO_MDOC, EHIC_MSO_MDOC, PDA1_MSO_MDOC],
-  "vc+sd-jwt": [PID_SD_JWT_VC, EHIC_SD_JWT_VC, PDA1_SD_JWT_VC]
+  "dc+sd-jwt": [PID_SD_JWT_VC, EHIC_SD_JWT_VC, PDA1_SD_JWT_VC]
 }
 
 export const getAttestationByFormatAndType =

--- a/src/app/core/constants/attestations-per-format.ts
+++ b/src/app/core/constants/attestations-per-format.ts
@@ -130,9 +130,23 @@ export const PID_SD_JWT_VC_ATTRIBUTE_MAP: { [id: string]: string } = {
   "expiry_date": "exp"
 }
 
+export const PID_SD_JWT_VC_DEPRECATED: SdJwtVcAttestation = {
+  ...PID_SD_JWT_VC,
+  format: AttestationFormat.SD_JWT_VC_DEPRECATED
+}
+export const EHIC_SD_JWT_VC_DEPRECATED: SdJwtVcAttestation = {
+  ...EHIC_SD_JWT_VC,
+  format: AttestationFormat.SD_JWT_VC_DEPRECATED
+}
+export const PDA1_SD_JWT_VC_DEPRECATED: SdJwtVcAttestation = {
+  ...PDA1_SD_JWT_VC,
+  format: AttestationFormat.SD_JWT_VC_DEPRECATED
+}
+
 export const ATTESTATIONS_BY_FORMAT: { [id: string]: Attestation[] } = {
   "mso_mdoc": [PID_MSO_MDOC, MDL_MSO_MDOC, PHOTO_ID_MSO_MDOC, AGE_OVER_18_MSO_MDOC, EHIC_MSO_MDOC, PDA1_MSO_MDOC],
-  "dc+sd-jwt": [PID_SD_JWT_VC, EHIC_SD_JWT_VC, PDA1_SD_JWT_VC]
+  "dc+sd-jwt": [PID_SD_JWT_VC, EHIC_SD_JWT_VC, PDA1_SD_JWT_VC],
+  "vc+sd-jwt": [PID_SD_JWT_VC_DEPRECATED, EHIC_SD_JWT_VC_DEPRECATED, PDA1_SD_JWT_VC_DEPRECATED]
 }
 
 export const getAttestationByFormatAndType =

--- a/src/app/core/models/attestation/AttestationFormat.ts
+++ b/src/app/core/models/attestation/AttestationFormat.ts
@@ -1,5 +1,6 @@
 export enum AttestationFormat {
   MSO_MDOC = "mso_mdoc",
   SD_JWT_VC = "dc+sd-jwt",
+  SD_JWT_VC_DEPRECATED = "vc+sd-jwt",
   JWT_VC_JSON = "jwt_vc_json"
 }

--- a/src/app/core/models/attestation/AttestationFormat.ts
+++ b/src/app/core/models/attestation/AttestationFormat.ts
@@ -1,5 +1,5 @@
 export enum AttestationFormat {
   MSO_MDOC = "mso_mdoc",
-  SD_JWT_VC = "vc+sd-jwt",
+  SD_JWT_VC = "dc+sd-jwt",
   JWT_VC_JSON = "jwt_vc_json"
 }

--- a/src/app/core/models/attestation/Attestations.ts
+++ b/src/app/core/models/attestation/Attestations.ts
@@ -14,7 +14,7 @@ export type MsoMdocAttestation  = {
 }
 
 export type SdJwtVcAttestation = {
-  format: AttestationFormat.SD_JWT_VC,
+  format: AttestationFormat.SD_JWT_VC | AttestationFormat.SD_JWT_VC_DEPRECATED,
   vct: string,
   attestationDef: AttestationDefinition
   attributePath: (attribute: DataElement) => string,

--- a/src/app/core/models/presentation/InputDescriptor.ts
+++ b/src/app/core/models/presentation/InputDescriptor.ts
@@ -18,5 +18,9 @@ export type Format = {
   "dc+sd-jwt"?: {
     "sd-jwt_alg_values": string[],
     "kb-jwt_alg_values": string[]
+  },
+  "vc+sd-jwt"?: {
+    "sd-jwt_alg_values": string[],
+    "kb-jwt_alg_values": string[]
   }
 }

--- a/src/app/core/models/presentation/InputDescriptor.ts
+++ b/src/app/core/models/presentation/InputDescriptor.ts
@@ -15,7 +15,7 @@ export type Format = {
   mso_mdoc?: {
     alg: string[]
   },
-  "vc+sd-jwt"?: {
+  "dc+sd-jwt"?: {
     "sd-jwt_alg_values": string[],
     "kb-jwt_alg_values": string[]
   }

--- a/src/app/core/services/dcql-service.ts
+++ b/src/app/core/services/dcql-service.ts
@@ -58,7 +58,7 @@ export class DCQLService {
 
     let query: CredentialQuery = {
       id: queryId,
-      format: format === AttestationFormat.MSO_MDOC ? 'mso_mdoc' : 'vc+sd-jwt',
+      format: format === AttestationFormat.MSO_MDOC ? 'mso_mdoc' : 'dc+sd-jwt',
       meta:
         format === AttestationFormat.MSO_MDOC
           ? {

--- a/src/app/core/services/dcql-service.ts
+++ b/src/app/core/services/dcql-service.ts
@@ -58,7 +58,7 @@ export class DCQLService {
 
     let query: CredentialQuery = {
       id: queryId,
-      format: format === AttestationFormat.MSO_MDOC ? 'mso_mdoc' : 'dc+sd-jwt',
+      format: format,
       meta:
         format === AttestationFormat.MSO_MDOC
           ? {

--- a/src/app/core/services/decoders-registry.service.ts
+++ b/src/app/core/services/decoders-registry.service.ts
@@ -20,6 +20,7 @@ export class DecodersRegistryService {
     this.dictionary[AttestationFormat.MSO_MDOC] = msoMdocAttestationDecoder;
     this.dictionary[AttestationFormat.JWT_VC_JSON] = jwtVcJsonAttestationDecoder;
     this.dictionary[AttestationFormat.SD_JWT_VC] = sdJwtVcAttestationDecoder;
+    this.dictionary[AttestationFormat.SD_JWT_VC_DEPRECATED] = sdJwtVcAttestationDecoder;
   }
 
   decoderOf(attestationFormat: AttestationFormat): AttestationDecoder {

--- a/src/app/core/services/decoders/SdJwtVcAttestationDecoder.ts
+++ b/src/app/core/services/decoders/SdJwtVcAttestationDecoder.ts
@@ -19,7 +19,7 @@ export class SdJwtVcAttestationDecoder implements AttestationDecoder {
   }
 
   supports(format: AttestationFormat): boolean {
-    return format === AttestationFormat.SD_JWT_VC;
+    return format === AttestationFormat.SD_JWT_VC || format === AttestationFormat.SD_JWT_VC_DEPRECATED;
   }
 
   decode(attestation: string, nonce: string): Observable<PresentedAttestation> {

--- a/src/app/core/services/presentation-definition.service.ts
+++ b/src/app/core/services/presentation-definition.service.ts
@@ -89,6 +89,13 @@ export class PresentationDefinitionService {
             vpFormatsPerType[AttestationFormat.SD_JWT_VC] as SdJwtVcVpFormat,
             includeAttributes
           );
+        case AttestationFormat.SD_JWT_VC_DEPRECATED:
+          return this.sdJwtVcInputDescriptorOf(
+            attestation,
+            presentationPurpose,
+            vpFormatsPerType[AttestationFormat.SD_JWT_VC_DEPRECATED] as SdJwtVcVpFormat,
+            includeAttributes
+          );
       }
     } else {
       console.error(
@@ -130,7 +137,7 @@ export class PresentationDefinitionService {
       name: attestation.attestationDef.name,
       purpose: presentationPurpose,
       format: {
-        'dc+sd-jwt': {
+        [attestation.format]: {
           'sd-jwt_alg_values': vpFormat['sd-jwt_alg_values'],
           'kb-jwt_alg_values': vpFormat['kb-jwt_alg_values'],
         },

--- a/src/app/core/services/presentation-definition.service.ts
+++ b/src/app/core/services/presentation-definition.service.ts
@@ -130,7 +130,7 @@ export class PresentationDefinitionService {
       name: attestation.attestationDef.name,
       purpose: presentationPurpose,
       format: {
-        'vc+sd-jwt': {
+        'dc+sd-jwt': {
           'sd-jwt_alg_values': vpFormat['sd-jwt_alg_values'],
           'kb-jwt_alg_values': vpFormat['kb-jwt_alg_values'],
         },

--- a/src/app/features/invoke-wallet/services/wallet-response-processor.service.spec.ts
+++ b/src/app/features/invoke-wallet/services/wallet-response-processor.service.spec.ts
@@ -114,7 +114,7 @@ describe('WalletResponseProcessorService', () => {
                 name: 'Person Identification Data (PID)',
                 purpose: '',
                 format: {
-                  'vc+sd-jwt': {
+                  'dc+sd-jwt': {
                     'sd-jwt_alg_values': ['ES256', 'ES384', 'ES512'],
                     'kb-jwt_alg_values': [
                       'RS256',
@@ -158,7 +158,7 @@ describe('WalletResponseProcessorService', () => {
               descriptor_map: [
                 {
                   id: 'eea9e21a-e33a-4a65-9bfe-62d402419d25',
-                  format: 'vc+sd-jwt',
+                  format: 'dc+sd-jwt',
                   path: '$',
                 },
               ],

--- a/src/app/features/invoke-wallet/services/wallet-response-processor.service.spec.ts
+++ b/src/app/features/invoke-wallet/services/wallet-response-processor.service.spec.ts
@@ -199,12 +199,12 @@ describe('WalletResponseProcessorService', () => {
                 },
                 claims: [
                   {
-                    namespace: 'eu.europa.ec.eudi.pid.1',
-                    claim_name: 'family_name',
+                    path: ['eu.europa.ec.eudi.pid.1', 'family_name'],
+                    intent_to_retain: false,
                   },
                   {
-                    namespace: 'eu.europa.ec.eudi.pid.1',
-                    claim_name: 'given_name',
+                    path: ['eu.europa.ec.eudi.pid.1', 'given_name'],
+                    intent_to_retain: false,
                   },
                 ],
               },


### PR DESCRIPTION
This PR adds a new option in the attestation format dropdown, `dc+sd-jwt`.
The option to use the old media type, `vc+sd-jwt`, remains.

Closes #108 