### PR TITLE
Align mdoc input descriptor with ISO 23220-4 & 18013-7.

### DIFF
--- a/src/app/core/models/presentation/Constraint.ts
+++ b/src/app/core/models/presentation/Constraint.ts
@@ -1,5 +1,6 @@
 import { FieldConstraint } from './FieldConstraint';
 
 export type Constraint = {
+  limit_disclosure?: 'required' | 'preferred',
   fields: FieldConstraint[]
 }

--- a/src/app/core/services/presentation-definition-service.ts
+++ b/src/app/core/services/presentation-definition-service.ts
@@ -61,7 +61,7 @@ export class PresentationDefinitionService {
     if (attestation) {
       switch (attestation.format) {
         case AttestationFormat.MSO_MDOC:
-          return this.msoMdocInputDescriptorOf(attestation, presentationPurpose, includeAttributes);
+          return this.msoMdocInputDescriptorOf(attestation, includeAttributes);
         case AttestationFormat.SD_JWT_VC:
           return this.sdJwtVcInputDescriptorOf(attestation, presentationPurpose, includeAttributes);
       }
@@ -73,13 +73,10 @@ export class PresentationDefinitionService {
 
   private msoMdocInputDescriptorOf(
     attestation: MsoMdocAttestation,
-    presentationPurpose: string,
     includeAttributes?: string[]
   ): InputDescriptor {
     return {
       id: attestation.doctype,
-      name: attestation.attestationDef.name,
-      purpose: presentationPurpose,
       format: {
         mso_mdoc: {
           alg: [
@@ -90,6 +87,7 @@ export class PresentationDefinitionService {
         }
       },
       constraints: {
+        limit_disclosure: 'required',
         fields: this.fieldConstraints(attestation, includeAttributes)
       }
     };


### PR DESCRIPTION
Remove `name` and `purpose` from input_descriptor when requesting `mso_mdoc` credentials.
Add `limit_disclosure` to input_descriptor constraints when requesting `mso_mdoc` credentials.

Closes #125 
Closes #126 