### PR TITLE
Ensure all Transaction Event Log data are displayed

### DIFF
--- a/src/app/core/models/EventLog.ts
+++ b/src/app/core/models/EventLog.ts
@@ -3,8 +3,5 @@ export type EventLog = {
   timestamp: number;
   event: string;
   actor: string;
-  data: {
-    key: string;
-    value: any;
-  };
+  data: object;
 }

--- a/src/app/core/services/verifier-endpoint.service.ts
+++ b/src/app/core/services/verifier-endpoint.service.ts
@@ -62,13 +62,13 @@ export class VerifierEndpointService {
       .pipe(
         map((data: any) => {
           return data.events.map((event: EventLog) => {
-            this.getTransactionData(event).forEach((key: string) => {
-              const value = event[key as keyof EventLog] ?? {};
-              event.data = {
-                key: key,
-                value,
-              };
-            });
+            let data = { };
+            this.getTransactionData(event)
+              .forEach((key: string) => {
+                const value = event[key as keyof EventLog];
+                data = { ...data, [key]: value}
+              });
+            event.data = data;
             return event;
           });
         })


### PR DESCRIPTION
This PR updates `EventLog`, and `getsTransactionEventsLogs` so that all Transaction Event Data are being displayed in the UI.