### PR TITLE
Set default `origin` to `window.location.origin` in DC API initializa…

### DIFF
--- a/src/app/features/dc-api-redirect/dc-api-redirect.component.ts
+++ b/src/app/features/dc-api-redirect/dc-api-redirect.component.ts
@@ -105,7 +105,7 @@ export class DcApiRedirectComponent implements OnInit {
 			initialization_request: {
 				nonce: claims.nonce,
 				dcql_query: claims.dcql_query,
-				origin: claims.origin,
+				origin: claims.origin ?? window.location.origin,
 			},
 		};
 


### PR DESCRIPTION
This pr fixes the DC API ITB integration